### PR TITLE
test: #35 e2eテストのコードの全体的な見直し

### DIFF
--- a/e2e/log.spec.ts
+++ b/e2e/log.spec.ts
@@ -102,7 +102,7 @@ describe('ログページ', () => {
       // 金額が変更されているか
       await expect(
         page.locator('table > tbody > tr:nth-of-type(1) > td:nth-of-type(2)')
-      ).toHaveText('3000');
+      ).toHaveText('3,000');
       // ホームに遷移
       await page.goto('http://localhost:3000/main');
       // 残高が正しく変更されているか（差額の-2000円されているか）
@@ -110,7 +110,7 @@ describe('ログページ', () => {
         page.getByRole('heading', {
           name: 'balance'
         })
-      ).toHaveText('3000');
+      ).toHaveText('3,000');
     });
     test('編集失敗（タイトル＋金額→バリデーションエラー）', async () => {
       // ページ遷移
@@ -142,7 +142,7 @@ describe('ログページ', () => {
       // 金額が変更されていないか
       await expect(
         page.locator('table > tbody > tr:nth-of-type(1) > td:nth-of-type(2)')
-      ).toHaveText('5000');
+      ).toHaveText('5,000');
       // ホームに遷移
       await page.goto('http://localhost:3000/main');
       // 残高が変更されていないか
@@ -150,7 +150,7 @@ describe('ログページ', () => {
         page.getByRole('heading', {
           name: 'balance'
         })
-      ).toHaveText('5000');
+      ).toHaveText('5,000');
     });
     test('編集失敗（タイトル→バリデーションエラー）', async () => {
       // ページ遷移
@@ -182,7 +182,7 @@ describe('ログページ', () => {
       // 金額が変更されていないか
       await expect(
         page.locator('table > tbody > tr:nth-of-type(1) > td:nth-of-type(2)')
-      ).toHaveText('5000');
+      ).toHaveText('5,000');
       // ホームに遷移
       await page.goto('http://localhost:3000/main');
       // 残高が変更されていないか
@@ -190,7 +190,7 @@ describe('ログページ', () => {
         page.getByRole('heading', {
           name: 'balance'
         })
-      ).toHaveText('5000');
+      ).toHaveText('5,000');
     });
     test('編集失敗（金額→バリデーションエラー）', async () => {
       // ページ遷移
@@ -222,7 +222,7 @@ describe('ログページ', () => {
       // 金額が変更されていないか
       await expect(
         page.locator('table > tbody > tr:nth-of-type(1) > td:nth-of-type(2)')
-      ).toHaveText('5000');
+      ).toHaveText('5,000');
       // ホームに遷移
       await page.goto('http://localhost:3000/main');
       // 残高が変更されていないか
@@ -230,7 +230,7 @@ describe('ログページ', () => {
         page.getByRole('heading', {
           name: 'balance'
         })
-      ).toHaveText('5000');
+      ).toHaveText('5,000');
     });
   });
   describe('ログ削除', () => {

--- a/e2e/main.spec.ts
+++ b/e2e/main.spec.ts
@@ -91,7 +91,7 @@ describe('メインページ', () => {
         page.getByRole('heading', {
           name: 'balance'
         })
-      ).toHaveText('5000');
+      ).toHaveText('5,000');
       // 欲しい物アイテムの進捗率が正しく増える（5000 / 20000 * 100)
       await expect(page.getByText('25%')).toBeVisible();
       // もう１件送信
@@ -108,7 +108,7 @@ describe('メインページ', () => {
         page.getByRole('heading', {
           name: 'balance'
         })
-      ).toHaveText('5350');
+      ).toHaveText('5,350');
       await expect(page.getByText('27%')).toBeVisible();
       // ログページにログが作成される
       // ページ遷移
@@ -125,7 +125,7 @@ describe('メインページ', () => {
         page.locator(
           `table > tbody > tr:nth-of-type(${rowCount}) > td:nth-of-type(2)`
         )
-      ).toHaveText('5000');
+      ).toHaveText('5,000');
       // ２件目のログが最終行の一つ上にあるか
       await expect(
         page.locator(
@@ -247,7 +247,7 @@ describe('メインページ', () => {
         page.getByRole('heading', {
           name: 'balance'
         })
-      ).toHaveText('30000');
+      ).toHaveText('30,000');
     });
   });
 });

--- a/e2e/wantedItem.spec.ts
+++ b/e2e/wantedItem.spec.ts
@@ -78,7 +78,7 @@ describe('欲しい物リストページ', () => {
       // 商品名の確認
       await expect(firstArticle.locator('h3')).toHaveText('Refaドライヤー');
       // 価格の確認
-      await expect(firstArticle.locator('p')).toHaveText('Price: ¥30000');
+      await expect(firstArticle.locator('p')).toHaveText('¥30,000');
       // 詳細リンクの確認
       await expect(
         firstArticle.locator('a:has-text("詳細を見る")')
@@ -100,7 +100,7 @@ describe('欲しい物リストページ', () => {
       // 商品名の確認
       await expect(firstArticle.locator('h3')).toHaveText('Refaドライヤー');
       // 価格の確認
-      await expect(firstArticle.locator('p')).toHaveText('Price: ¥30000');
+      await expect(firstArticle.locator('p')).toHaveText('¥30,000');
       // 詳細リンクの確認
       await expect(
         firstArticle.locator('a:has-text("詳細を見る")')
@@ -176,7 +176,7 @@ describe('欲しい物リストページ', () => {
         'Panasonicドライヤー'
       );
       // 価格が変更されているか
-      await expect(firstArticle.locator('p')).toHaveText('Price: ¥20000');
+      await expect(firstArticle.locator('p')).toHaveText('¥20,000');
       // 詳細リンクが変更されているか
       await expect(
         firstArticle.locator('a:has-text("詳細を見る")')
@@ -304,7 +304,7 @@ describe('欲しい物リストページ', () => {
       // 商品名が変更されていないか
       await expect(firstArticle.locator('h3')).toHaveText('Refaドライヤー');
       // 価格が変更されていないか
-      await expect(firstArticle.locator('p')).toHaveText('Price: ¥30000');
+      await expect(firstArticle.locator('p')).toHaveText('¥30,000');
       // 詳細リンクが変更されていないか
       await expect(
         firstArticle.locator('a:has-text("詳細を見る")')
@@ -350,7 +350,7 @@ describe('欲しい物リストページ', () => {
       // 商品名が変更されていないか
       await expect(firstArticle.locator('h3')).toHaveText('Refaドライヤー');
       // 価格が変更されていないか
-      await expect(firstArticle.locator('p')).toHaveText('Price: ¥30000');
+      await expect(firstArticle.locator('p')).toHaveText('¥30,000');
       // 詳細リンクが変更されていないか
       await expect(
         firstArticle.locator('a:has-text("詳細を見る")')


### PR DESCRIPTION
## Issue
#35 

## 概要
過去の実装で回らなくなったe2eテストコードの改修

## 対応内容
・金額表示にカンマをつけた対応に合わせてテストコードも修正。
・欲しいものリストの値段表示箇所から「Price:」を削除

## 動作確認内容
ローカルでe2eテストを実行し、問題なくpassしたことを確認した。

## 影響範囲
なし

## 未対応内容・課題
なし

## レビュー観点
テストコードに不備がないか。

## 補足
なし