### PR TITLE
Feature/ci setup slack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,7 +234,6 @@ jobs:
       SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
     steps:
       - uses: technote-space/workflow-conclusion-action@v1
-      - uses: 8398a7/action-slack@v2
         with:
           status: ${{ env.WORKFLOW_CONCLUSION }}
       # 成功

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   # Slack開始通知
-  slackStartNotification:
+  SlackStartNotification:
     name: Slack-Start-Notification
     runs-on: ubuntu-latest
     env:
@@ -17,12 +17,13 @@ jobs:
       - name: Notify Start of CI
         uses: rtCamp/action-slack-notify@v2
         env:
-          SLACK_TITLE: Deploy / Start
-          SLACK_COLOR: warning
+          SLACK_TITLE: CI / Start
+          SLACK_COLOR: good
           SLACK_MESSAGE: '<!here> CIを開始します🎭'
+
   # 型チェック
   TypeCheck:
-    needs: slackStartNotification
+    needs: SlackStartNotification
     runs-on: ubuntu-latest
     steps:
       # ブランチを取得
@@ -61,7 +62,7 @@ jobs:
         run: npm run typecheck
 
   # ビルドチェック
-  Build:
+  BuildCheck:
     needs: TypeCheck
     runs-on: ubuntu-latest
     steps:
@@ -102,7 +103,7 @@ jobs:
 
   # ユニットテスト
   UnitTest:
-    needs: Build
+    needs: BuildCheck
     runs-on: ubuntu-latest
     steps:
       # ブランチを取得
@@ -142,7 +143,7 @@ jobs:
 
   # E2Eテスト
   E2ETest:
-    needs: Build
+    needs: BuildCheck
     runs-on: ubuntu-latest
     env:
       # データベースの設定
@@ -205,7 +206,7 @@ jobs:
       # Prismaのマイグレーションを実行
       - name: Run Prisma migrate
         run: npx prisma migrate deploy
-      # 自動でOAuth認証（Google）するためのテストデータをシード
+      # 自動でOAuth認証（Google）を通すためのテストデータをシード
       - name: Seed test data
         run: psql -h localhost -U postgres -d postgres -f ./prisma/seed.sql
         env:
@@ -220,19 +221,22 @@ jobs:
           PGPASSWORD: postgres
       # E2Eテストを実行
       - name: Run E2E Test
-        run: npm run playwrigh
+        run: npm run playwright
 
-  # Slack通知
+  # Slack終了通知
   SlackEndNotification:
     name: Slack-End-Notification
     runs-on: ubuntu-latest
-    needs: [TypeCheck, Build, UnitTest, E2ETest]
+    # すべてのジョブが完了したら実行
+    needs: [TypeCheck, BuildCheck, UnitTest, E2ETest]
+    # 失敗したジョブがあっても実行
     if: always()
     env:
       SLACK_USERNAME: Github Actions
       SLACK_ICON: https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png
       SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
     steps:
+      # Workflow の結果を取得するアクション（env.WORKFLOW_CONCLUSIONに結果が格納される）
       - uses: technote-space/workflow-conclusion-action@v1
         with:
           status: ${{ env.WORKFLOW_CONCLUSION }}
@@ -241,15 +245,14 @@ jobs:
         uses: rtCamp/action-slack-notify@v2
         if: ${{ env.WORKFLOW_CONCLUSION == 'success' }}
         env:
-          SLACK_TITLE: Deploy / Success
+          SLACK_TITLE: CI / Success
           SLACK_COLOR: good
           SLACK_MESSAGE: '<!here> CIが成功しました🚀'
-
       # 失敗
       - name: Slack Notification on Failure
         uses: rtCamp/action-slack-notify@v2
         if: ${{ env.WORKFLOW_CONCLUSION != 'success' }}
         env:
-          SLACK_TITLE: Deploy / Failure
+          SLACK_TITLE: CI / Failure
           SLACK_COLOR: danger
           SLACK_MESSAGE: '<!here> CIが失敗しました👿'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         env:
           SLACK_TITLE: Deploy / Start
           SLACK_COLOR: warning
-          SLACK_MESSAGE: ${{ github.ref_name }} ブランチのCIを開始します🛠️
+          SLACK_MESSAGE: @here CIを開始します🎭
   # 型チェック
   TypeCheck:
     needs: slackStartNotification
@@ -239,7 +239,7 @@ jobs:
         env:
           SLACK_TITLE: Deploy / Success
           SLACK_COLOR: good
-          SLACK_MESSAGE: ${{ github.ref_name }}ブランチのCIが成功しました🚀
+          SLACK_MESSAGE: @here CIが成功しました🚀
 
       # 失敗
       - name: Slack Notification on Failure
@@ -248,4 +248,4 @@ jobs:
         env:
           SLACK_TITLE: Deploy / Failure
           SLACK_COLOR: danger
-          SLACK_MESSAGE: ${{ github.ref_name }}ブランチのCIが失敗しました😢
+          SLACK_MESSAGE: @here CIが失敗しました👿

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,24 @@ on:
   workflow_dispatch:
 
 jobs:
+  # Slack開始通知
+  slackStartNotification:
+    name: Slack-Start-Notification
+    runs-on: ubuntu-latest
+    env:
+      SLACK_USERNAME: Github Actions
+      SLACK_ICON: https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png
+      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
+    steps:
+      - name: Notify Start of CI
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_TITLE: Deploy / Start
+          SLACK_COLOR: warning
+          SLACK_MESSAGE: ${{ github.ref_name }} ブランチのCIを開始します🛠️
   # 型チェック
   TypeCheck:
+    needs: slackStartNotification
     runs-on: ubuntu-latest
     steps:
       # ブランチを取得
@@ -205,3 +221,31 @@ jobs:
       # E2Eテストを実行
       - name: Run E2E Test
         run: npm run playwright
+
+  # Slack通知
+  SlackEndNotification:
+    name: Slack-End-Notification
+    runs-on: ubuntu-latest
+    needs: [TypeCheck, Build, UnitTest, E2ETest]
+    env:
+      SLACK_USERNAME: Github Actions
+      SLACK_ICON: https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png
+      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
+    steps:
+      # 成功
+      - name: Slack Notification on Success
+        uses: rtCamp/action-slack-notify@v2
+        if: ${{ success() }}
+        env:
+          SLACK_TITLE: Deploy / Success
+          SLACK_COLOR: good
+          SLACK_MESSAGE: ${{ github.ref_name }}ブランチのCIが成功しました🚀
+
+      # 失敗
+      - name: Slack Notification on Failure
+        uses: rtCamp/action-slack-notify@v2
+        if: ${{ failure() }}
+        env:
+          SLACK_TITLE: Deploy / Failure
+          SLACK_COLOR: danger
+          SLACK_MESSAGE: ${{ github.ref_name }}ブランチのCIが失敗しました😢

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     env:
       SLACK_USERNAME: Github Actions
       SLACK_ICON: https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png
-      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
+      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
     steps:
       - name: Notify Start of CI
         uses: rtCamp/action-slack-notify@v2
@@ -230,7 +230,7 @@ jobs:
     env:
       SLACK_USERNAME: Github Actions
       SLACK_ICON: https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png
-      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
+      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
     steps:
       # 成功
       - name: Slack Notification on Success

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         env:
           SLACK_TITLE: Deploy / Start
           SLACK_COLOR: warning
-          SLACK_MESSAGE: '@here CIを開始します🎭'
+          SLACK_MESSAGE: '<!here> CIを開始します🎭'
   # 型チェック
   TypeCheck:
     needs: slackStartNotification
@@ -239,7 +239,7 @@ jobs:
         env:
           SLACK_TITLE: Deploy / Success
           SLACK_COLOR: good
-          SLACK_MESSAGE: '@here CIが成功しました🚀'
+          SLACK_MESSAGE: '<!here> CIが成功しました🚀'
 
       # 失敗
       - name: Slack Notification on Failure
@@ -248,4 +248,4 @@ jobs:
         env:
           SLACK_TITLE: Deploy / Failure
           SLACK_COLOR: danger
-          SLACK_MESSAGE: '@here CIが失敗しました👿'
+          SLACK_MESSAGE: '<!here> CIが失敗しました👿'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         env:
           SLACK_TITLE: Deploy / Start
           SLACK_COLOR: warning
-          SLACK_MESSAGE: @here CIを開始します🎭
+          SLACK_MESSAGE: '@here CIを開始します🎭'
   # 型チェック
   TypeCheck:
     needs: slackStartNotification
@@ -239,7 +239,7 @@ jobs:
         env:
           SLACK_TITLE: Deploy / Success
           SLACK_COLOR: good
-          SLACK_MESSAGE: @here CIが成功しました🚀
+          SLACK_MESSAGE: '@here CIが成功しました🚀'
 
       # 失敗
       - name: Slack Notification on Failure
@@ -248,4 +248,4 @@ jobs:
         env:
           SLACK_TITLE: Deploy / Failure
           SLACK_COLOR: danger
-          SLACK_MESSAGE: @here CIが失敗しました👿
+          SLACK_MESSAGE: '@here CIが失敗しました👿'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
   # 型チェック
   TypeCheck:
     needs: slackStartNotification
-    runs-on: ubuntus-latest
+    runs-on: ubuntu-latest
     steps:
       # ブランチを取得
       - uses: actions/checkout@v4
@@ -220,7 +220,7 @@ jobs:
           PGPASSWORD: postgres
       # E2Eテストを実行
       - name: Run E2E Test
-        run: npm run playwright
+        run: npm run playwrigh
 
   # Slack通知
   SlackEndNotification:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
   # 型チェック
   TypeCheck:
     needs: slackStartNotification
-    runs-on: ubuntu-latest
+    runs-on: ubuntus-latest
     steps:
       # ブランチを取得
       - uses: actions/checkout@v4
@@ -152,7 +152,7 @@ jobs:
     services:
       # データベースのコンテナを起動
       postgres:
-        image: postgrjes:16
+        image: postgres:16
         # データベースのユーザー名、パスワード、データベース名の設定
         env:
           POSTGRES_USER: postgres
@@ -233,10 +233,14 @@ jobs:
       SLACK_ICON: https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png
       SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
     steps:
+      - uses: technote-space/workflow-conclusion-action@v1
+      - uses: 8398a7/action-slack@v2
+        with:
+          status: ${{ env.WORKFLOW_CONCLUSION }}
       # 成功
       - name: Slack Notification on Success
         uses: rtCamp/action-slack-notify@v2
-        if: ${{ success() }}
+        if: ${{ env.WORKFLOW_CONCLUSION == 'success' }}
         env:
           SLACK_TITLE: Deploy / Success
           SLACK_COLOR: good
@@ -245,7 +249,7 @@ jobs:
       # 失敗
       - name: Slack Notification on Failure
         uses: rtCamp/action-slack-notify@v2
-        if: ${{ failure() }}
+        if: ${{ env.WORKFLOW_CONCLUSION != 'success' }}
         env:
           SLACK_TITLE: Deploy / Failure
           SLACK_COLOR: danger

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,7 +152,7 @@ jobs:
     services:
       # データベースのコンテナを起動
       postgres:
-        image: postgres:16
+        image: postgrjes:16
         # データベースのユーザー名、パスワード、データベース名の設定
         env:
           POSTGRES_USER: postgres
@@ -227,6 +227,7 @@ jobs:
     name: Slack-End-Notification
     runs-on: ubuntu-latest
     needs: [TypeCheck, Build, UnitTest, E2ETest]
+    if: always()
     env:
       SLACK_USERNAME: Github Actions
       SLACK_ICON: https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png


### PR DESCRIPTION
## Issue
#32 

## 概要
CIの結果がSlackに通知されるようにワークフローを修正。

## 対応内容
・CI開始時にSlackに通知が届くようにした。
・CI終了時にSlackに成功 or 失敗の通知が届くようにした。

## 動作確認内容
本ブランチのpushにて確認した。（成功時、失敗時ともに確認した。）

## 影響範囲
なし

## 未対応内容・課題
なし

## レビュー観点
ワークフローの内容に不足がないか。

## 補足
なし