### PR TITLE
update: #61 欲しい物リストページのボタン位置変更

### DIFF
--- a/src/app/wantedItemManagement/_components/_PurchasedItemList/Row.tsx
+++ b/src/app/wantedItemManagement/_components/_PurchasedItemList/Row.tsx
@@ -36,17 +36,6 @@ export const Row = ({ item }: { item: WantedItem }) => {
         </div>
       </div>
       <div className="flex flex-col items-end space-y-2">
-        <Link
-          href={`/wantedItemManagement/edit/${item.id}`}
-          aria-label={`Edit ${item.name}`}
-        >
-          <Button
-            aria-label={`Edit ${item.name}`}
-            className="bg-green-500 font-bold hover:bg-green-700"
-          >
-            編集
-          </Button>
-        </Link>
         <div className="flex space-x-2">
           <Link
             href={`/wantedItemManagement/cancelPurchased/${item.id}`}
@@ -60,17 +49,28 @@ export const Row = ({ item }: { item: WantedItem }) => {
             </Button>
           </Link>
           <Link
-            href={`/wantedItemManagement/delete/${item.id}`}
-            aria-label={`Delete ${item.name}`}
+            href={`/wantedItemManagement/edit/${item.id}`}
+            aria-label={`Edit ${item.name}`}
           >
             <Button
-              aria-label={`Delete ${item.name}`}
-              className="bg-gray-500 font-bold hover:bg-gray-700"
+              aria-label={`Edit ${item.name}`}
+              className="bg-green-500 font-bold hover:bg-green-700"
             >
-              削除
+              編集
             </Button>
           </Link>
         </div>
+        <Link
+          href={`/wantedItemManagement/delete/${item.id}`}
+          aria-label={`Delete ${item.name}`}
+        >
+          <Button
+            aria-label={`Delete ${item.name}`}
+            className="bg-gray-500 font-bold hover:bg-gray-700"
+          >
+            削除
+          </Button>
+        </Link>
       </div>
     </article>
   );

--- a/src/app/wantedItemManagement/_components/_WantedItemList/Row.tsx
+++ b/src/app/wantedItemManagement/_components/_WantedItemList/Row.tsx
@@ -53,17 +53,6 @@ export const Row = async ({ item }: { item: WantedItem }) => {
         </div>
       </div>
       <div className="flex flex-col items-end space-y-2">
-        <Link
-          href={`/wantedItemManagement/edit/${item.id}`}
-          aria-label={`Edit ${item.name}`}
-        >
-          <Button
-            aria-label={`Edit ${item.name}`}
-            className="bg-green-500 font-bold hover:bg-green-700"
-          >
-            編集
-          </Button>
-        </Link>
         <div className="flex space-x-2">
           {/* 値段に対する残高の進捗が100％以上の時のみ、購入ボタンを表示 */}
           {balance.balance / item.price >= 1 && (
@@ -80,17 +69,28 @@ export const Row = async ({ item }: { item: WantedItem }) => {
             </Link>
           )}
           <Link
-            href={`/wantedItemManagement/delete/${item.id}`}
-            aria-label={`Delete ${item.name}`}
+            href={`/wantedItemManagement/edit/${item.id}`}
+            aria-label={`Edit ${item.name}`}
           >
             <Button
-              aria-label={`Delete ${item.name}`}
-              className="bg-gray-500 font-bold hover:bg-gray-700"
+              aria-label={`Edit ${item.name}`}
+              className="bg-green-500 font-bold hover:bg-green-700"
             >
-              削除
+              編集
             </Button>
           </Link>
         </div>
+        <Link
+          href={`/wantedItemManagement/delete/${item.id}`}
+          aria-label={`Delete ${item.name}`}
+        >
+          <Button
+            aria-label={`Delete ${item.name}`}
+            className="bg-gray-500 font-bold hover:bg-gray-700"
+          >
+            削除
+          </Button>
+        </Link>
       </div>
     </article>
   );


### PR DESCRIPTION
## Issue
#61 

## 概要
欲しい物リストページのボタン位置変更

## 対応内容
「購入」「購入取消」ボタンの位置が削除ボタンの横となっており、低く、不格好だったため、編集ボタンの横に位置を変更。

## 動作確認内容
目視で確認

## 影響範囲
アイテムの名前が長い時に少し圧迫感が生じてしまう。特にiPhoneSEなどの横幅が狭い端末の際に。
だが、許容範囲。

## 未対応内容・課題
なし

## レビュー観点
なし

## 補足
なし